### PR TITLE
Pre-merge peek

### DIFF
--- a/.github/workflows/Chibi_ci_build.yml
+++ b/.github/workflows/Chibi_ci_build.yml
@@ -8,6 +8,7 @@ name: Chibi_Ultica composer
 
 env:
   TILESET: Chibi_Ultica
+  COMPOSE_URL: https://raw.githubusercontent.com/sulyi/Cataclysm-DDA/fix_compose_exclusion/tools/gfx_tools/compose.py
   COMPOSE_ARGS: --use-all
   BUILD_DIR: build
 
@@ -64,7 +65,7 @@ jobs:
         id: build
         run: |
           mkdir "$BUILD_DIR"
-          wget -q -P "$BUILD_DIR" https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py \
+          wget -q -P "$BUILD_DIR" "$COMPOSE_URL" \
           || echo "Error: Failed to get compose.py"
 
           python3 "$BUILD_DIR/compose.py" $COMPOSE_ARGS "gfx/$TILESET" "$BUILD_DIR"


### PR DESCRIPTION
Make as you will of it / with it, but I want you to know I'm trying to help you out with this, as a thanks for your help.

Until https://github.com/CleverRaven/Cataclysm-DDA/pull/56096 got merged you can use it. I'll try not to break things.
After that you can revert it or just change `$COMPOS_URL` back to `https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/master/tools/gfx_tools/compose.py`.